### PR TITLE
Fixes init script for Radarr V3

### DIFF
--- a/net-nntp/radarr/files/radarr.init
+++ b/net-nntp/radarr/files/radarr.init
@@ -13,8 +13,7 @@ etc_dir="/etc/radarr"
 var_dir="/var/lib/radarr"
 log_dir="/var/log/radarr"
 log_file="radarr.log"
-program="$APP_DIR/Radarr.exe"
-bin=`which mono`
+program="$APP_DIR/Radarr"
 
 check_config() {
     
@@ -37,7 +36,7 @@ start() {
 
         start-stop-daemon --start --background --make-pidfile --pidfile ${pidfile}\
         -u ${USER} -g ${GROUP}\
-    --exec ${bin} ${program} -- \
+    --exec ${program} -- \
     --daemon --log=${log_dir}/${log_file} --data_dir ${var_dir}
         eend $?
 }

--- a/net-nntp/radarr/radarr-3.0.1.4259.ebuild
+++ b/net-nntp/radarr/radarr-3.0.1.4259.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit systemd
+
+SRC_URI="https://github.com/Radarr/Radarr/releases/download/v${PV}/Radarr.master.${PV}.linux-core-x64.tar.gz"
+
+DESCRIPTION="A fork of Sonarr to work with movies a la Couchpotato."
+HOMEPAGE="https://www.radarr.video"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64"
+RDEPEND="
+	acct-group/radarr
+	acct-user/radarr
+	>=dev-lang/mono-6.6.0.161
+	media-video/mediainfo
+	dev-db/sqlite"
+
+MY_PN=Radarr
+S="${WORKDIR}/${MY_PN}"
+
+src_install() {
+	newconfd "${FILESDIR}/${PN}.conf" ${PN}
+	newinitd "${FILESDIR}/${PN}.init" ${PN}
+
+	keepdir /var/lib/${PN}
+	fowners -R ${PN}:${PN} /var/lib/${PN}
+
+	insinto /etc/${PN}
+	insopts -m0660 -o ${PN} -g ${PN}
+
+	insinto /etc/logrotate.d
+	insopts -m0644 -o root -g root
+	newins "${FILESDIR}/${PN}.logrotate" ${PN}
+
+	dodir  "/usr/share/${PN}"
+	cp -R "${WORKDIR}/${MY_PN}/." "${D}/usr/share/radarr" || die "Install failed!"
+
+	systemd_dounit "${FILESDIR}/radarr.service"
+	systemd_newunit "${FILESDIR}/radarr.service" "${PN}@.service"
+}


### PR DESCRIPTION
The radarr executable seems to be changed from Radarr.exe to Radarr. The executable can be run stand alone. mono is not necessary in the start command.