### PR TITLE
Add gitignore to metadata

### DIFF
--- a/metadata/.gitignore
+++ b/metadata/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/md5-cache


### PR DESCRIPTION
This commit was written against the current master branch of xartin's
gentoo-overlay.
Currently the overlay does not ignore the md5-cache nor the cache
which can be generated inside of the metadata directory.
An md5-cache directory is created upon
executing the Q/A program pkgcheck with `pkgcheck scan .`
With the gitignore, the auto-generated md5-cache will be properly
ignored.
Without the gitignore, the auto-generated md5-cache will not be
ignored and so much be constantly deleted.
This gitignore is present in both the main gentoo overlay and sci's
overlay.
https://github.com/gentoo/gentoo/blob/master/metadata/.gitignore
https://github.com/gentoo/sci/blob/master/metadata/.gitignore

This commit was written and submitted by Lucas Mitrak.
This commit was tested with repoman and pgkcheck for Q/A.