### PR TITLE
.github/workflows: add repoman and pkgcheck

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -1,0 +1,19 @@
+name: pkgcheck
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run pkgcheck
+      uses: pkgcore/pkgcheck-action@v1
+      with:
+        args: --keywords=-RedundantVersion,-MissingAccountIdentifier,-OldPackageUpdate,-VisibleVcsPkg

--- a/.github/workflows/repoman.yml
+++ b/.github/workflows/repoman.yml
@@ -1,0 +1,22 @@
+name: repoman
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup master gentoo repository
+      run: |
+        ./scripts/setup-master-gentoo.sh
+    - name: Setup and run Repoman
+      run: |
+        ./scripts/setup-and-run-repoman.sh
+

--- a/scripts/setup-and-run-repoman.sh
+++ b/scripts/setup-and-run-repoman.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+# Maintainer: Andrew Ammerlaan <andrewammerlaan@gentoo.org>
+#
+# This sets up repoman and runs the latest version
+#
+# TODO: Force repoman to output in colour
+
+### Setup prerequisites
+python3 -m pip install --upgrade pip
+pip install lxml pyyaml
+sudo groupadd -g 250 portage
+sudo useradd -g portage -d /var/tmp/portage -s /bin/false -u 250 portage
+
+### Sync the portage repository
+git clone https://github.com/gentoo/portage.git
+cd portage
+
+# Get all versions, and read into array
+mapfile -t RM_VERSIONS < <( git tag | grep repoman | sort -u )
+
+# Select latests version (last element in array)
+RM_VERS="${RM_VERSIONS[-1]}"
+
+# Checkout this version
+git checkout tags/${RM_VERS} -b ${RM_VERS}
+
+cd ..
+
+### Run repoman
+python3 portage/repoman/bin/repoman -dx full

--- a/scripts/setup-master-gentoo.sh
+++ b/scripts/setup-master-gentoo.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+# Maintainer: Andrew Ammerlaan <andrewammerlaan@gentoo.org>
+#
+# Fetch and setup the latest ::gentoo
+
+sudo mkdir -p /var/db/repos/gentoo /etc/portage /var/cache/distfiles
+wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | sudo tar xz -C /var/db/repos/gentoo --strip-components=1
+sudo wget "https://www.gentoo.org/dtd/metadata.dtd" -O /var/cache/distfiles/metadata.dtd
+sudo wget "https://gitweb.gentoo.org/proj/portage.git/plain/cnf/repos.conf" -O /etc/portage/repos.conf
+sudo ln -s /var/db/repos/gentoo/profiles/default/linux/amd64/17.1 /etc/portage/make.profile


### PR DESCRIPTION
Currently, this overlay does not have any QA checks for continuous
integration. This means that updates can be merged that violate
Gentoo's QA, and existing violations are not publically seen and
so generally probably will not be dealt with.
Without this commit, this overlay will continue to lack QA checks.
With this commit, this overlay will have QA checks every time a push or
pull request is made on master. In addition, a QA check will occur
everyday. If you think a QA check occuring everyday is too much, I will
push another commit onto this branch that removes the daily checks.
This QA system is lifted from Gentoo's science overlay. I did not
include duplicates because there are no duplicates of these packages in
Gentoo's main overlay; however, I can add it if it is desired.
Finally, this overlay does not fail any QA checks, but it simply has
minor issues. Therefore, github should not show the overlay as currently
failing the QA check.
The same QA system in science:
https://github.com/gentoo/sci/tree/master/.github/workflows
https://github.com/gentoo/sci/tree/master/scripts
This commit was written and submitted by Lucas Mitrak.

Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>